### PR TITLE
Interview trainer view

### DIFF
--- a/Components/Pages/InterviewLibrary/InterviewLibrary.razor
+++ b/Components/Pages/InterviewLibrary/InterviewLibrary.razor
@@ -1,6 +1,7 @@
 ﻿@page "/InterviewLibrary"
 
 @inject JobBank.Components.Pages.InterviewLibrary.ViewModels.IInterviewLibraryViewModel InterviewLibraryViewModel
+@inherits ViewModelBase<IInterviewLibraryViewModel>
 @rendermode InteractiveServer
 @attribute [Authorize]
 
@@ -27,7 +28,7 @@
                 </div>
                 <div class="card-body" style="overflow-y: auto; max-height: 70vh;">
 
-                    <QuickGrid Class="table table-hover align-middle mb-0"
+                    <QuickGrid @ref="grid" Class="table table-hover align-middle mb-0"                               
                                TGridItem="InterviewDTO"
                                ItemsProvider="InterviewLibraryViewModel.GetInterviews"
                                Pagination="InterviewLibraryViewModel.Pagination"
@@ -49,7 +50,7 @@
 
                         <TemplateColumn Context="interview" Title="Actions" Class="text-end">
                             <div class="btn-group btn-group-sm">
-
+                                <button class="btn btn-primary" @onclick="() => InterviewLibraryViewModel.SelectInterviewAsync(interview)">Transcript</button>
                             </div>
                         </TemplateColumn>
                     </QuickGrid>
@@ -92,5 +93,16 @@
 </div>
 
 @code {
+    private QuickGrid<InterviewDTO>? grid;
 
+    private async Task HandleSelectInterview(InterviewDTO interview)
+    {
+        await InterviewLibraryViewModel.SelectInterviewAsync(interview);
+        
+        // Force QuickGrid to re-render
+        if (grid is not null)
+        {
+            await grid.RefreshDataAsync();
+        }
+    }
 }

--- a/Components/Pages/InterviewLibrary/InterviewLibrary.razor
+++ b/Components/Pages/InterviewLibrary/InterviewLibrary.razor
@@ -28,7 +28,7 @@
                 </div>
                 <div class="card-body" style="overflow-y: auto; max-height: 70vh;">
 
-                    <QuickGrid @ref="grid" Class="table table-hover align-middle mb-0"                               
+                    <QuickGrid Class="table table-hover align-middle mb-0"                               
                                TGridItem="InterviewDTO"
                                ItemsProvider="InterviewLibraryViewModel.GetInterviews"
                                Pagination="InterviewLibraryViewModel.Pagination"
@@ -93,16 +93,5 @@
 </div>
 
 @code {
-    private QuickGrid<InterviewDTO>? grid;
-
-    private async Task HandleSelectInterview(InterviewDTO interview)
-    {
-        await InterviewLibraryViewModel.SelectInterviewAsync(interview);
-        
-        // Force QuickGrid to re-render
-        if (grid is not null)
-        {
-            await grid.RefreshDataAsync();
-        }
-    }
+    
 }

--- a/Components/Pages/InterviewLibrary/InterviewLibrary.razor
+++ b/Components/Pages/InterviewLibrary/InterviewLibrary.razor
@@ -95,9 +95,9 @@
                         <div class="card-header"><h5>Training</h5></div>
                         <div class="card-body overflow-auto" style="max-height: 70vh;">
 
-                            @if (InterviewLibraryViewModel.TrainingAnalysys != null && InterviewLibraryViewModel.TrainingAnalysys.Training.Any())
+                            @if (InterviewLibraryViewModel.TrainingAnalysis != null && InterviewLibraryViewModel.TrainingAnalysis.Training.Any())
                             {
-                                @foreach (var content in InterviewLibraryViewModel.TrainingAnalysys.Training)
+                                @foreach (var content in InterviewLibraryViewModel.TrainingAnalysis.Training)
                                 {
                                     <div class="mb-4 p-3 border rounded">
                                         <!-- Training Topic -->

--- a/Components/Pages/InterviewLibrary/InterviewLibrary.razor
+++ b/Components/Pages/InterviewLibrary/InterviewLibrary.razor
@@ -5,8 +5,8 @@
 @rendermode InteractiveServer
 @attribute [Authorize]
 
-<div class="container-fluid px-5">
-    <div class="row">
+<div class="container-fluid px-4">
+    <div class="row g-4 align-items-stretch">
         <div class="col">
             <div class="d-flex justify-content-between align-items-center my-4">
                 <div>
@@ -23,69 +23,201 @@
     <div class="row mb-4 align-items-stretch">
         <div class="col-md-7 d-flex">
             <div class="d-flex flex-column flex-fill">
-                <div class="card-header">
-                    <div>Interviews</div>
-                </div>
-                <div class="card-body" style="overflow-y: auto; max-height: 70vh;">
+                <div class="card h-100">
+                    <div class="card-header fw-semibold">Interviews</div>
+                    <div class="card-body p-0">
+                        <QuickGrid Class="table table-hover align-middle mb-0"
+                                   TGridItem="InterviewDTO"
+                                   ItemsProvider="InterviewLibraryViewModel.GetInterviews"
+                                   Pagination="InterviewLibraryViewModel.Pagination"
+                                   RowClass="@InterviewLibraryViewModel.GetRowCssClass"
+                                   Virtualize="true">
+                            <PropertyColumn Property="interview => interview.JobTitle" Title="Job Title" Sortable="true" />
 
-                    <QuickGrid Class="table table-hover align-middle mb-0"                               
-                               TGridItem="InterviewDTO"
-                               ItemsProvider="InterviewLibraryViewModel.GetInterviews"
-                               Pagination="InterviewLibraryViewModel.Pagination"
-                               RowClass="@InterviewLibraryViewModel.GetRowCssClass"
-                               Virtualize="true">
-                        <PropertyColumn Property="interview => interview.JobTitle" Title="Job Title" Sortable="true" />
+                            <PropertyColumn Property="interview => interview.Company" Sortable="true">
+                                <ColumnOptions>
+                                    <div class="p-2">
+                                        <input type="search" class="form-control form-control-lg"
+                                               @bind="InterviewLibraryViewModel.CompanySearch" @bind:event="oninput"
+                                               placeholder="Filter Employer..." autofocus />
+                                    </div>
+                                </ColumnOptions>
+                            </PropertyColumn>
 
-                        <PropertyColumn Property="interview => interview.Company" Sortable="true">
-                            <ColumnOptions>
-                                <div class="p-2">
-                                    <input type="search" class="form-control form-control-lg"
-                                           @bind="InterviewLibraryViewModel.CompanySearch" @bind:event="oninput"
-                                           placeholder="Filter Employer..." autofocus />
+                            <PropertyColumn Property="interview => interview.CompletedAtUtc" Format="MMM dd, yyyy" Title="Applied" Sortable="true" />
+
+                            <TemplateColumn Context="interview" Title="Actions" Class="text-end">
+                                <div class="btn-group btn-group-sm">
+                                    <button class="btn btn-outline-primary" @onclick="() => InterviewLibraryViewModel.SelectInterviewAsync(interview)">Transcript</button>
+                                    <button class="btn btn-secondary" @onclick="() => InterviewLibraryViewModel.LoadTraining(interview)" disabled="@(interview.TrainingId == 0)">Training</button>
                                 </div>
-                            </ColumnOptions>
-                        </PropertyColumn>
-                        
-                        <PropertyColumn Property="interview => interview.CompletedAtUtc" Format="MMM dd, yyyy" Title="Applied" Sortable="true" />
-
-                        <TemplateColumn Context="interview" Title="Actions" Class="text-end">
-                            <div class="btn-group btn-group-sm">
-                                <button class="btn btn-primary" @onclick="() => InterviewLibraryViewModel.SelectInterviewAsync(interview)">Transcript</button>
-                            </div>
-                        </TemplateColumn>
-                    </QuickGrid>
-                </div>
-                <div class="mt-3">
-                    <Paginator State="@InterviewLibraryViewModel.Pagination" />
+                            </TemplateColumn>
+                        </QuickGrid>
+                    </div>
+                    <div class="mt-3">
+                        <Paginator State="@InterviewLibraryViewModel.Pagination" />
+                    </div>
                 </div>
             </div>
+
         </div>
+
         <div class="col-md-5 d-flex">
             <div class="d-flex flex-column flex-fill">
-                <div class="card-header">
-                    <h5 class="card-title">Interview</h5>
-                </div>
-                <div class="text-body">
-                    <div class="card-body d-flex flex-column">
-                        <div id="chat-container" style="overflow-y: auto; max-height: 57vh;">
-                            @if (!InterviewLibraryViewModel.History.Any())
+
+                <div class="card h-100">
+
+                    @if (InterviewLibraryViewModel.IsInterview)     
+                    {
+                    <div class="card-header"><h5>Interview</h5></div>
+                    <div class="card-body overflow-auto" style="max-height: 70vh;">
+                        @if (!InterviewLibraryViewModel.History.Any())
+                        {
+                            <div class="loading-shell">
+                                Transcript no longer available. WORKS Commons does not serialize conversations to ensure privacy.
+                            </div>
+                        }
+                        @foreach (var chat in InterviewLibraryViewModel.History)
+                        {
+                            <div class="d-flex @(chat.Role == InterviewRole.User.ToString() ? "justify-content-end" : "justify-content-start") mb-2">
+                                <div class="p-3 rounded-3 @(chat.Role == InterviewRole.User.ToString() ? "bg-primary text-white" : "bg-light border")"
+                                     style="max-width: 65%;">
+                                    <div>@chat.Content</div>
+                                    <small class="opacity-50">@chat.Timestamp.ToString("t")</small>
+                                </div>
+                            </div>
+                        }
+                    </div>
+                    }
+
+                    @if(InterviewLibraryViewModel.IsTraining)
+                    {
+                        <div class="card-header"><h5>Training</h5></div>
+                        <div class="card-body overflow-auto" style="max-height: 70vh;">
+
+                            @if (InterviewLibraryViewModel.TrainingAnalysys != null && InterviewLibraryViewModel.TrainingAnalysys.Training.Any())
+                            {
+                                @foreach (var content in InterviewLibraryViewModel.TrainingAnalysys.Training)
+                                {
+                                    <div class="mb-4 p-3 border rounded">
+                                        <!-- Training Topic -->
+                                        <h6 class="fw-bold text-primary mb-2">
+                                            <i class="bi bi-book"></i> @content.TrainingTopic
+                                        </h6>
+
+                                        <!-- Training Type & Source -->
+                                        <div class="mb-3 small text-muted">
+                                            <span class="badge bg-info">@content.TrainingType</span>
+                                            @if (!string.IsNullOrEmpty(content.TrainingSource))
+                                            {
+                                                <span class="ms-2">Source: <strong>@content.TrainingSource</strong></span>
+                                            }
+                                        </div>
+
+                                        <!-- Abstract -->
+                                        @if (!string.IsNullOrEmpty(content.Abstract))
+                                        {
+                                            <div class="mb-3">
+                                                <p class="text-break mb-0">@content.Abstract</p>
+                                            </div>
+                                        }
+
+                                        <!-- Prerequisites -->
+                                        @if (content.Prerequisites != null && content.Prerequisites.Any())
+                                        {
+                                            <div class="mb-3">
+                                                <h6 class="fw-semibold small mb-2">
+                                                    <i class="bi bi-list-check"></i> Prerequisites
+                                                </h6>
+                                                <ul class="small mb-0 ps-3">
+                                                    @foreach (var prereq in content.Prerequisites)
+                                                    {
+                                                        <li class="mb-2">
+                                                            <strong>@prereq.ReferenceTitle</strong>
+                                                            @if (!string.IsNullOrEmpty(prereq.ReferenceType))
+                                                            {
+                                                                <span class="badge bg-secondary ms-1">@prereq.ReferenceType</span>
+                                                            }
+                                                            @if (!string.IsNullOrEmpty(prereq.ReferenceSource))
+                                                            {
+                                                                <br />
+                                                                <small class="text-muted">@prereq.ReferenceSource</small>
+                                                            }
+                                                            @if (!string.IsNullOrEmpty(prereq.ReferenceLink))
+                                                            {
+                                                                <br />
+                                                                <a href="@prereq.ReferenceLink" target="_blank" class="small">
+                                                                    <i class="bi bi-link-45deg"></i> Learn more
+                                                                </a>
+                                                            }
+                                                        </li>
+                                                    }
+                                                </ul>
+                                            </div>
+                                        }
+
+                                        <!-- Where to Focus -->
+                                        @if (content.WhereToFocus != null && content.WhereToFocus.Any())
+                                        {
+                                            <div class="mb-3">
+                                                <h6 class="fw-semibold small mb-2">
+                                                    <i class="bi bi-target"></i> Focus Areas
+                                                </h6>
+                                                <ul class="small mb-0 ps-3">
+                                                    @foreach (var focus in content.WhereToFocus)
+                                                    {
+                                                        <li>@focus</li>
+                                                    }
+                                                </ul>
+                                            </div>
+                                        }
+
+                                        <!-- Homework Questions -->
+                                        @if (content.HomeworkQuestions != null && content.HomeworkQuestions.Any())
+                                        {
+                                            <div class="mb-3">
+                                                <h6 class="fw-semibold small mb-2">
+                                                    <i class="bi bi-pencil-square"></i> Practice Questions
+                                                </h6>
+                                                <ul class="small mb-0 ps-3">
+                                                    @foreach (var question in content.HomeworkQuestions)
+                                                    {
+                                                        <li class="mb-2">@question</li>
+                                                    }
+                                                </ul>
+                                            </div>
+                                        }
+
+                                        <!-- Mastery Task -->
+                                        @if (content.MasteryTask != null)
+                                        {
+                                            <div class="p-2 bg-light border-start border-warning border-3">
+                                                <h6 class="fw-semibold small mb-2">
+                                                    <i class="bi bi-star-fill text-warning"></i> Mastery Task
+                                                </h6>
+                                                <p class="small mb-2 fw-bold">@content.MasteryTask.Topic</p>
+                                                @if (content.MasteryTask.EssentialSubtopics != null && content.MasteryTask.EssentialSubtopics.Any())
+                                                {
+                                                    <ul class="small mb-0 ps-3">
+                                                        @foreach (var subtopic in content.MasteryTask.EssentialSubtopics)
+                                                        {
+                                                            <li>@subtopic</li>
+                                                        }
+                                                    </ul>
+                                                }
+                                            </div>
+                                        }
+                                    </div>
+                                }
+                            }
+                            else
                             {
                                 <div class="loading-shell">
-                                    Transcript no longer available. WORKS Commons does not serialize conversations to ensure privacy.
-                                </div>
-                            }
-                            @foreach (var chat in InterviewLibraryViewModel.History)
-                            {
-                                <div class="d-flex @(chat.Role == InterviewRole.User.ToString() ? "justify-content-end" : "justify-content-start") mb-2">
-                                    <div class="p-3 rounded-3 @(chat.Role == InterviewRole.User.ToString() ? "bg-primary text-white" : "bg-light border")"
-                                         style="max-width: 65%;">
-                                        <div>@chat.Content</div>
-                                        <small class="opacity-50">@chat.Timestamp.ToString("t")</small>
-                                    </div>
+                                    Training content not available.
                                 </div>
                             }
                         </div>
-                    </div>
+                    }
                 </div>
             </div>
         </div>
@@ -93,5 +225,5 @@
 </div>
 
 @code {
-    
+
 }

--- a/Components/Pages/InterviewLibrary/InterviewLibrary.razor
+++ b/Components/Pages/InterviewLibrary/InterviewLibrary.razor
@@ -1,5 +1,95 @@
 ﻿@page "/InterviewLibrary"
-<h3>Interview Library</h3>
+
+@inject JobBank.Components.Pages.InterviewLibrary.ViewModels.IInterviewLibraryViewModel InterviewLibraryViewModel
+@rendermode InteractiveServer
+@attribute [Authorize]
+
+<div class="container-fluid px-5">
+    <div class="row">
+        <div class="col">
+            <div class="d-flex justify-content-between align-items-center my-4">
+                <div>
+                    <h1 class="display-5 mb-0">Interview Library</h1>
+                </div>
+                <div class="d-flex gap-2">
+                    <a href="/jobposts" class="btn btn-outline-secondary">
+                        <i class="bi bi-arrow-left"></i> Back to List
+                    </a>
+                </div>
+            </div>
+        </div>
+    </div>
+    <div class="row mb-4 align-items-stretch">
+        <div class="col-md-7 d-flex">
+            <div class="d-flex flex-column flex-fill">
+                <div class="card-header">
+                    <div>Interviews</div>
+                </div>
+                <div class="card-body" style="overflow-y: auto; max-height: 70vh;">
+
+                    <QuickGrid Class="table table-hover align-middle mb-0"
+                               TGridItem="InterviewDTO"
+                               ItemsProvider="InterviewLibraryViewModel.GetInterviews"
+                               Pagination="InterviewLibraryViewModel.Pagination"
+                               RowClass="@InterviewLibraryViewModel.GetRowCssClass"
+                               Virtualize="true">
+                        <PropertyColumn Property="interview => interview.JobTitle" Title="Job Title" Sortable="true" />
+
+                        <PropertyColumn Property="interview => interview.Company" Sortable="true">
+                            <ColumnOptions>
+                                <div class="p-2">
+                                    <input type="search" class="form-control form-control-lg"
+                                           @bind="InterviewLibraryViewModel.CompanySearch" @bind:event="oninput"
+                                           placeholder="Filter Employer..." autofocus />
+                                </div>
+                            </ColumnOptions>
+                        </PropertyColumn>
+                        
+                        <PropertyColumn Property="interview => interview.CompletedAtUtc" Format="MMM dd, yyyy" Title="Applied" Sortable="true" />
+
+                        <TemplateColumn Context="interview" Title="Actions" Class="text-end">
+                            <div class="btn-group btn-group-sm">
+
+                            </div>
+                        </TemplateColumn>
+                    </QuickGrid>
+                </div>
+                <div class="mt-3">
+                    <Paginator State="@InterviewLibraryViewModel.Pagination" />
+                </div>
+            </div>
+        </div>
+        <div class="col-md-5 d-flex">
+            <div class="d-flex flex-column flex-fill">
+                <div class="card-header">
+                    <h5 class="card-title">Interview</h5>
+                </div>
+                <div class="text-body">
+                    <div class="card-body d-flex flex-column">
+                        <div id="chat-container" style="overflow-y: auto; max-height: 57vh;">
+                            @if (!InterviewLibraryViewModel.History.Any())
+                            {
+                                <div class="loading-shell">
+                                    Transcript no longer available. WORKS Commons does not serialize conversations to ensure privacy.
+                                </div>
+                            }
+                            @foreach (var chat in InterviewLibraryViewModel.History)
+                            {
+                                <div class="d-flex @(chat.Role == InterviewRole.User.ToString() ? "justify-content-end" : "justify-content-start") mb-2">
+                                    <div class="p-3 rounded-3 @(chat.Role == InterviewRole.User.ToString() ? "bg-primary text-white" : "bg-light border")"
+                                         style="max-width: 65%;">
+                                        <div>@chat.Content</div>
+                                        <small class="opacity-50">@chat.Timestamp.ToString("t")</small>
+                                    </div>
+                                </div>
+                            }
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
 
 @code {
 

--- a/Components/Pages/InterviewLibrary/InterviewLibrary.razor.css
+++ b/Components/Pages/InterviewLibrary/InterviewLibrary.razor.css
@@ -1,8 +1,95 @@
 ﻿body {
 }
+.card-body {
+    padding: 1.25rem 1.5rem;
+}
+
+.card-header, .card-body {
+    box-shadow: 0 1px 3px rgba(0,0,0,0.1);
+}
+
+.card-header, .card-body {
+    box-shadow: 0 1px 3px rgba(0,0,0,0.1);
+}
 
 ::deep .selected-row {
     background-color: #b5e2eb !important;
     font-weight: bold !important;
 }
+
+.bg-primary.text-white {
+    background-color: #0d6efd !important;
+}
+
+.bg-light.border {
+    background-color: #f1f3f5 !important;
+}
+
+/* Interview Library layout refinements */
+.container-fluid {
+    padding-inline: 2rem;
+}
+
+/* Section spacing */
+.row.g-4 {
+    gap: 1.5rem;
+}
+
+/* Card styling */
+.card {
+    border: none;
+    border-radius: 0.75rem;
+    box-shadow: 0 2px 6px rgba(0,0,0,0.08);
+    background-color: #fff;
+}
+
+.card-header {
+    font-weight: 600;
+    background-color: #f8f9fa;
+    border-bottom: 1px solid #dee2e6;
+    padding: 0.75rem 1.25rem;
+}
+
+.card-body {
+    padding: 1.25rem 1.5rem;
+}
+
+
+.table-hover tbody tr:hover {
+    background-color: #f8f9fa;
+}
+
+.table td, .table th {
+    padding: 0.75rem 1rem;
+}
+
+.table thead th {
+    position: sticky;
+    top: 0;
+    background: #fff;
+    z-index: 2;
+}
+
+/* Table improvements */
+.table th, .table td {
+    padding: 0.75rem 1rem;
+    vertical-align: middle;
+}
+
+.table-hover tbody tr:hover {
+    background-color: #f8f9fa;
+}
+
+.table thead th {
+    position: sticky;
+    top: 0;
+    background: #fff;
+    z-index: 2;
+}
+
+/* Chat area */
+#chat-container .rounded-3 {
+    max-width: 75%;
+}
+
 

--- a/Components/Pages/InterviewLibrary/InterviewLibrary.razor.css
+++ b/Components/Pages/InterviewLibrary/InterviewLibrary.razor.css
@@ -1,0 +1,8 @@
+﻿body {
+}
+
+::deep .selected-row {
+    background-color: #b5e2eb !important;
+    font-weight: bold !important;
+}
+

--- a/Components/Pages/InterviewLibrary/ViewModels/IInterviewLibraryViewModel.cs
+++ b/Components/Pages/InterviewLibrary/ViewModels/IInterviewLibraryViewModel.cs
@@ -7,23 +7,59 @@ namespace JobBank.Components.Pages.InterviewLibrary.ViewModels
 {
     public interface IInterviewLibraryViewModel : IAsyncInitialization
     {
+        /// <summary>
+        /// Retrieves paginated interviews for the current user with optional company filtering.
+        /// </summary>
         ValueTask<GridItemsProviderResult<InterviewDTO>> GetInterviews(GridItemsProviderRequest<InterviewDTO> request);
+        
+        /// <summary>
+        /// Company name filter for interview search.
+        /// </summary>
         string CompanySearch { get; set; }
+        
+        /// <summary>
+        /// Pagination state for the interview grid.
+        /// </summary>
         PaginationState Pagination { get; }
+        
+        /// <summary>
+        /// Returns the CSS class for a row based on selection state.
+        /// </summary>
         string? GetRowCssClass(InterviewDTO jobPost);
 
+        /// <summary>
+        /// Interview message history/transcript for the selected interview.
+        /// </summary>
         List<ChatMessage> History { get; set; }
 
-        InterviewTrainingAnalysisResultDTO TrainingAnalysys { get; set; }
+        /// <summary>
+        /// Training analysis content for the selected interview.
+        /// </summary>
+        InterviewTrainingAnalysisResultDTO? TrainingAnalysis { get; set; }
 
-        Task SelectInterviewAsync(InterviewDTO args);
-
+        /// <summary>
+        /// Indicates whether the interview view is currently active.
+        /// </summary>
         bool IsInterview { get; set; }
 
+        /// <summary>
+        /// Indicates whether the training view is currently active.
+        /// </summary>
         bool IsTraining { get; set; }
 
-        Task LoadTraining(InterviewDTO interview);
+        /// <summary>
+        /// Loads and displays an interview's transcript from cache or protected storage.
+        /// </summary>
+        Task SelectInterviewAsync(InterviewDTO? args);
 
-        public event Action? OnRequestUIUpdate;
+        /// <summary>
+        /// Loads and displays training content for an interview.
+        /// </summary>
+        Task LoadTraining(InterviewDTO? interview);
+
+        /// <summary>
+        /// Event fired when the ViewModel state changes and the UI should re-render.
+        /// </summary>
+        event Action? OnRequestUIUpdate;
     }
 }

--- a/Components/Pages/InterviewLibrary/ViewModels/IInterviewLibraryViewModel.cs
+++ b/Components/Pages/InterviewLibrary/ViewModels/IInterviewLibraryViewModel.cs
@@ -1,0 +1,16 @@
+﻿using JobBank.Management.Interview;
+using JobBank.ModelsDTO;
+using Microsoft.AspNetCore.Components.QuickGrid;
+
+namespace JobBank.Components.Pages.InterviewLibrary.ViewModels
+{
+    public interface IInterviewLibraryViewModel
+    {
+        ValueTask<GridItemsProviderResult<InterviewDTO>> GetInterviews(GridItemsProviderRequest<InterviewDTO> request);
+        string CompanySearch { get; set; }
+        PaginationState Pagination { get; }
+        string GetRowCssClass(InterviewDTO jobPost);
+
+        List<ChatMessage> History { get; set; }
+    }
+}

--- a/Components/Pages/InterviewLibrary/ViewModels/IInterviewLibraryViewModel.cs
+++ b/Components/Pages/InterviewLibrary/ViewModels/IInterviewLibraryViewModel.cs
@@ -14,7 +14,15 @@ namespace JobBank.Components.Pages.InterviewLibrary.ViewModels
 
         List<ChatMessage> History { get; set; }
 
+        InterviewTrainingAnalysisResultDTO TrainingAnalysys { get; set; }
+
         Task SelectInterviewAsync(InterviewDTO args);
+
+        bool IsInterview { get; set; }
+
+        bool IsTraining { get; set; }
+
+        Task LoadTraining(InterviewDTO interview);
 
         public event Action? OnRequestUIUpdate;
     }

--- a/Components/Pages/InterviewLibrary/ViewModels/IInterviewLibraryViewModel.cs
+++ b/Components/Pages/InterviewLibrary/ViewModels/IInterviewLibraryViewModel.cs
@@ -1,16 +1,21 @@
-﻿using JobBank.Management.Interview;
+﻿using JobBank.Components.Pages.Init;
+using JobBank.Management.Interview;
 using JobBank.ModelsDTO;
 using Microsoft.AspNetCore.Components.QuickGrid;
 
 namespace JobBank.Components.Pages.InterviewLibrary.ViewModels
 {
-    public interface IInterviewLibraryViewModel
+    public interface IInterviewLibraryViewModel : IAsyncInitialization
     {
         ValueTask<GridItemsProviderResult<InterviewDTO>> GetInterviews(GridItemsProviderRequest<InterviewDTO> request);
         string CompanySearch { get; set; }
         PaginationState Pagination { get; }
-        string GetRowCssClass(InterviewDTO jobPost);
+        string? GetRowCssClass(InterviewDTO jobPost);
 
         List<ChatMessage> History { get; set; }
+
+        Task SelectInterviewAsync(InterviewDTO args);
+
+        public event Action? OnRequestUIUpdate;
     }
 }

--- a/Components/Pages/InterviewLibrary/ViewModels/InterviewLibraryViewModel.cs
+++ b/Components/Pages/InterviewLibrary/ViewModels/InterviewLibraryViewModel.cs
@@ -2,6 +2,7 @@
 using JobBank.ModelsDTO;
 using JobBank.Services.Abstraction;
 using Microsoft.AspNetCore.Components.QuickGrid;
+using System.Text.Json;
 
 namespace JobBank.Components.Pages.InterviewLibrary.ViewModels
 {
@@ -11,18 +12,22 @@ namespace JobBank.Components.Pages.InterviewLibrary.ViewModels
         private readonly ILogger<InterviewLibraryViewModel> _logger;
         private readonly IIdentityService _identityService;
         private readonly IInterviewService _interviewService;
+        private readonly ITrainingService _trainingService;
         private InterviewDTO selected;
+        private readonly Dictionary<string, List<ChatMessage>> _historyCache = new(); // cache transcripts
 
         public InterviewLibraryViewModel(
             ILogger<InterviewLibraryViewModel> logger,
             IIdentityService identityService,
             IInterviewService interviewService,
-            IProtectedLocalStoreService<List<ChatMessage>> interviewMessagesStore)
+            IProtectedLocalStoreService<List<ChatMessage>> interviewMessagesStore,
+            ITrainingService trainingService)
         {
             _logger = logger;
             _identityService = identityService;
             _interviewService = interviewService;
             _interviewMessagesStore = interviewMessagesStore;
+            _trainingService = trainingService;
         }
 
         public string CompanySearch { get; set; } = string.Empty;
@@ -59,16 +64,30 @@ namespace JobBank.Components.Pages.InterviewLibrary.ViewModels
 
         public string? GetRowCssClass(InterviewDTO interview)
         {
-            return selected != null && selected.Equals(interview) ? "table-primary fw-bold" : null;
+            return selected != null && selected.Equals(interview) ? "selected-row" : null;
         }
 
         public async Task SelectInterviewAsync(InterviewDTO args)
         {
             selected = args;
+            IsInterview = true;
+            IsTraining = !IsInterview;
+
             var historyKey = $"interview-messages-{args.Id}-{args.JobPostId}";
+            
             try
-            {
-                History = await _interviewMessagesStore.LoadAsync(historyKey) ?? new List<ChatMessage>();
+            {                
+                if (_historyCache.TryGetValue(historyKey, out var cachedHistory))
+                {
+                    History = cachedHistory;
+                }
+                else
+                {
+                    var loadedHistory = await _interviewMessagesStore.LoadAsync(historyKey) ?? new List<ChatMessage>();
+                    _historyCache[historyKey] = loadedHistory;
+                    History = loadedHistory;
+                }
+                
                 OnRequestUIUpdate?.Invoke();
             }
             catch (Exception ex)
@@ -76,13 +95,31 @@ namespace JobBank.Components.Pages.InterviewLibrary.ViewModels
                 _logger.LogError(ex, "Failed to load interview messages for interview ID {InterviewId}", args.Id);
                 History = new List<ChatMessage>();
             }
-
-            Console.WriteLine($"Selected interview with ID: {args.Id}");
         }
 
         public async Task InitializeAsync()
         {
            OnRequestUIUpdate?.Invoke();            
         }
+
+        public InterviewTrainingAnalysisResultDTO TrainingAnalysys { get; set; }
+
+        public async Task LoadTraining(InterviewDTO interview)
+        {
+            selected = interview;
+            IsTraining = true;
+            IsInterview = !IsTraining;
+            
+            var training = await _trainingService.GetTrainingByIdAsync(interview.TrainingId);
+            if (training != null && !string.IsNullOrEmpty(training.Result))
+            {
+                TrainingAnalysys = JsonSerializer.Deserialize<InterviewTrainingAnalysisResultDTO>(training!.Result);
+            }
+
+            OnRequestUIUpdate?.Invoke();
+        }
+
+        public bool IsInterview { get; set; }
+        public bool IsTraining { get; set; }
     }
 }

--- a/Components/Pages/InterviewLibrary/ViewModels/InterviewLibraryViewModel.cs
+++ b/Components/Pages/InterviewLibrary/ViewModels/InterviewLibraryViewModel.cs
@@ -6,6 +6,10 @@ using System.Text.Json;
 
 namespace JobBank.Components.Pages.InterviewLibrary.ViewModels
 {
+    /// <summary>
+    /// ViewModel for managing the Interview Library page, handling interview transcript display and training content.
+    /// Implements caching for both interview messages and training data to optimize performance.
+    /// </summary>
     public class InterviewLibraryViewModel : IInterviewLibraryViewModel
     {
         private readonly IProtectedLocalStoreService<List<ChatMessage>> _interviewMessagesStore;
@@ -13,8 +17,14 @@ namespace JobBank.Components.Pages.InterviewLibrary.ViewModels
         private readonly IIdentityService _identityService;
         private readonly IInterviewService _interviewService;
         private readonly ITrainingService _trainingService;
-        private InterviewDTO selected;
-        private readonly Dictionary<string, List<ChatMessage>> _historyCache = new(); // cache transcripts
+        
+        private InterviewDTO? _selectedInterview;
+        private string _userId = string.Empty;
+        
+        // Cache configurations
+        private const int MaxCacheSize = 50; // Prevent unbounded memory growth
+        private readonly Dictionary<string, List<ChatMessage>> _historyCache = new();
+        private readonly Dictionary<int, InterviewTrainingAnalysisResultDTO> _trainingCache = new();
 
         public InterviewLibraryViewModel(
             ILogger<InterviewLibraryViewModel> logger,
@@ -36,10 +46,17 @@ namespace JobBank.Components.Pages.InterviewLibrary.ViewModels
 
         public List<ChatMessage> History { get; set; } = new();
 
-        private string _userId = string.Empty;
+        public InterviewTrainingAnalysisResultDTO? TrainingAnalysis { get; set; }
+
+        public bool IsInterview { get; set; }
+
+        public bool IsTraining { get; set; }
 
         public event Action? OnRequestUIUpdate;
 
+        /// <summary>
+        /// Gets the current user ID, caching it after the first retrieval.
+        /// </summary>
         private async Task<string> GetUserIdAsync()
         {
             if (string.IsNullOrEmpty(_userId))
@@ -49,29 +66,52 @@ namespace JobBank.Components.Pages.InterviewLibrary.ViewModels
             return _userId;
         }
 
+        /// <summary>
+        /// Retrieves paginated interviews for the current user with optional company filtering.
+        /// </summary>
         public async ValueTask<GridItemsProviderResult<InterviewDTO>> GetInterviews(GridItemsProviderRequest<InterviewDTO> request)
         {
-            var user = await GetUserIdAsync();
+            try
+            {
+                var user = await GetUserIdAsync();
 
-            var paginationResult = await _interviewService.GetInterviewsByUserIdWithPaginationAsync(
-                user,
-                CompanySearch,
-                request.StartIndex,
-                request.Count ?? 10);
+                var paginationResult = await _interviewService.GetInterviewsByUserIdWithPaginationAsync(
+                    user,
+                    CompanySearch,
+                    request.StartIndex,
+                    request.Count ?? 10);
 
-            return GridItemsProviderResult.From(paginationResult.Items.ToList(), paginationResult.TotalCount);
+                return GridItemsProviderResult.From(paginationResult.Items.ToList(), paginationResult.TotalCount);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Error retrieving interviews for pagination");
+                return GridItemsProviderResult.From(new List<InterviewDTO>(), 0);
+            }
         }
 
+        /// <summary>
+        /// Gets the CSS class for a row based on selection state.
+        /// </summary>
         public string? GetRowCssClass(InterviewDTO interview)
         {
-            return selected != null && selected.Equals(interview) ? "selected-row" : null;
+            return _selectedInterview != null && _selectedInterview.Equals(interview) ? "selected-row" : null;
         }
 
-        public async Task SelectInterviewAsync(InterviewDTO args)
+        /// <summary>
+        /// Loads and displays an interview's transcript from cache or protected storage.
+        /// </summary>
+        public async Task SelectInterviewAsync(InterviewDTO? args)
         {
-            selected = args;
+            if (args == null)
+            {
+                _logger.LogWarning("SelectInterviewAsync called with null interview");
+                return;
+            }
+
+            _selectedInterview = args;
             IsInterview = true;
-            IsTraining = !IsInterview;
+            IsTraining = false;
 
             var historyKey = $"interview-messages-{args.Id}-{args.JobPostId}";
             
@@ -84,6 +124,13 @@ namespace JobBank.Components.Pages.InterviewLibrary.ViewModels
                 else
                 {
                     var loadedHistory = await _interviewMessagesStore.LoadAsync(historyKey) ?? new List<ChatMessage>();
+                    
+                    // Manage cache size to prevent memory issues
+                    if (_historyCache.Count >= MaxCacheSize)
+                    {
+                        _historyCache.Remove(_historyCache.Keys.First());
+                    }
+                    
                     _historyCache[historyKey] = loadedHistory;
                     History = loadedHistory;
                 }
@@ -94,32 +141,80 @@ namespace JobBank.Components.Pages.InterviewLibrary.ViewModels
             {
                 _logger.LogError(ex, "Failed to load interview messages for interview ID {InterviewId}", args.Id);
                 History = new List<ChatMessage>();
+                IsInterview = false;
             }
         }
 
+        /// <summary>
+        /// Loads and displays training content for an interview.
+        /// Training data is cached to avoid repeated database queries.
+        /// </summary>
+        public async Task LoadTraining(InterviewDTO? interview)
+        {
+            if (interview == null || interview.TrainingId <= 0)
+            {
+                _logger.LogWarning("LoadTraining called with null or invalid interview");
+                return;
+            }
+
+            _selectedInterview = interview;
+            IsTraining = true;
+            IsInterview = false;
+            
+            try
+            {
+                // Check cache first
+                if (_trainingCache.TryGetValue(interview.TrainingId, out var cachedTraining))
+                {
+                    TrainingAnalysis = cachedTraining;
+                }
+                else
+                {
+                    var training = await _trainingService.GetTrainingByIdAsync(interview.TrainingId);
+                    
+                    if (training != null && !string.IsNullOrEmpty(training.Result))
+                    {
+                        TrainingAnalysis = JsonSerializer.Deserialize<InterviewTrainingAnalysisResultDTO>(training.Result);
+                        
+                        // Manage cache size
+                        if (_trainingCache.Count >= MaxCacheSize)
+                        {
+                            _trainingCache.Remove(_trainingCache.Keys.First());
+                        }
+                        
+                        if (TrainingAnalysis != null)
+                        {
+                            _trainingCache[interview.TrainingId] = TrainingAnalysis;
+                        }
+                    }
+                    else
+                    {
+                        _logger.LogWarning("Training data not found for TrainingId {TrainingId}", interview.TrainingId);
+                        TrainingAnalysis = null;
+                    }
+                }
+
+                OnRequestUIUpdate?.Invoke();
+            }
+            catch (JsonException ex)
+            {
+                _logger.LogError(ex, "Failed to deserialize training data for TrainingId {TrainingId}", interview.TrainingId);
+                TrainingAnalysis = null;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Failed to load training for interview ID {InterviewId}", interview.Id);
+                TrainingAnalysis = null;
+            }
+        }
+
+        /// <summary>
+        /// Initializes the ViewModel. Called by the component on initialization.
+        /// </summary>
         public async Task InitializeAsync()
         {
-           OnRequestUIUpdate?.Invoke();            
-        }
-
-        public InterviewTrainingAnalysisResultDTO TrainingAnalysys { get; set; }
-
-        public async Task LoadTraining(InterviewDTO interview)
-        {
-            selected = interview;
-            IsTraining = true;
-            IsInterview = !IsTraining;
-            
-            var training = await _trainingService.GetTrainingByIdAsync(interview.TrainingId);
-            if (training != null && !string.IsNullOrEmpty(training.Result))
-            {
-                TrainingAnalysys = JsonSerializer.Deserialize<InterviewTrainingAnalysisResultDTO>(training!.Result);
-            }
-
             OnRequestUIUpdate?.Invoke();
+            await Task.CompletedTask;
         }
-
-        public bool IsInterview { get; set; }
-        public bool IsTraining { get; set; }
     }
 }

--- a/Components/Pages/InterviewLibrary/ViewModels/InterviewLibraryViewModel.cs
+++ b/Components/Pages/InterviewLibrary/ViewModels/InterviewLibraryViewModel.cs
@@ -1,0 +1,64 @@
+﻿using JobBank.Management.Interview;
+using JobBank.ModelsDTO;
+using JobBank.Services.Abstraction;
+using Microsoft.AspNetCore.Components.QuickGrid;
+
+namespace JobBank.Components.Pages.InterviewLibrary.ViewModels
+{
+    public class InterviewLibraryViewModel : IInterviewLibraryViewModel
+    {
+        private readonly ILogger<InterviewLibraryViewModel> _logger;
+        private readonly IIdentityService _identityService;
+        private readonly IInterviewService _interviewService;
+
+        public InterviewLibraryViewModel(
+            ILogger<InterviewLibraryViewModel> logger,
+            IIdentityService identityService,
+            IInterviewService interviewService)
+        {
+            _logger = logger;
+            _identityService = identityService;
+            _interviewService = interviewService;
+        }
+
+        public string CompanySearch { get; set; } = string.Empty;
+
+        public PaginationState Pagination { get; } = new() { ItemsPerPage = 10 };
+
+        public List<ChatMessage> History { get; set; } = new();
+
+        private string _userId = string.Empty;
+
+        private async Task<string> GetUserIdAsync()
+        {
+            if (string.IsNullOrEmpty(_userId))
+            {
+                _userId = await _identityService.GetUserIdAsync();
+            }
+            return _userId;
+        }
+
+        public async ValueTask<GridItemsProviderResult<InterviewDTO>> GetInterviews(GridItemsProviderRequest<InterviewDTO> request)
+        {
+            var user = await GetUserIdAsync();
+            
+            var paginationResult = await _interviewService.GetInterviewsByUserIdWithPaginationAsync(
+                user, 
+                CompanySearch, 
+                request.StartIndex, 
+                request.Count ?? 10);
+
+            return GridItemsProviderResult.From(paginationResult.Items.ToList(), paginationResult.TotalCount);
+        }
+
+        public string GetRowCssClass(InterviewDTO interview)
+        {
+            if (!interview.Passed)
+            {
+                return "declined-row";
+            }
+
+            return "applied-row";
+        }
+    }
+}

--- a/Components/Pages/InterviewLibrary/ViewModels/InterviewLibraryViewModel.cs
+++ b/Components/Pages/InterviewLibrary/ViewModels/InterviewLibraryViewModel.cs
@@ -7,18 +7,22 @@ namespace JobBank.Components.Pages.InterviewLibrary.ViewModels
 {
     public class InterviewLibraryViewModel : IInterviewLibraryViewModel
     {
+        private readonly IProtectedLocalStoreService<List<ChatMessage>> _interviewMessagesStore;
         private readonly ILogger<InterviewLibraryViewModel> _logger;
         private readonly IIdentityService _identityService;
         private readonly IInterviewService _interviewService;
+        private InterviewDTO selected;
 
         public InterviewLibraryViewModel(
             ILogger<InterviewLibraryViewModel> logger,
             IIdentityService identityService,
-            IInterviewService interviewService)
+            IInterviewService interviewService,
+            IProtectedLocalStoreService<List<ChatMessage>> interviewMessagesStore)
         {
             _logger = logger;
             _identityService = identityService;
             _interviewService = interviewService;
+            _interviewMessagesStore = interviewMessagesStore;
         }
 
         public string CompanySearch { get; set; } = string.Empty;
@@ -28,6 +32,8 @@ namespace JobBank.Components.Pages.InterviewLibrary.ViewModels
         public List<ChatMessage> History { get; set; } = new();
 
         private string _userId = string.Empty;
+
+        public event Action? OnRequestUIUpdate;
 
         private async Task<string> GetUserIdAsync()
         {
@@ -41,24 +47,42 @@ namespace JobBank.Components.Pages.InterviewLibrary.ViewModels
         public async ValueTask<GridItemsProviderResult<InterviewDTO>> GetInterviews(GridItemsProviderRequest<InterviewDTO> request)
         {
             var user = await GetUserIdAsync();
-            
+
             var paginationResult = await _interviewService.GetInterviewsByUserIdWithPaginationAsync(
-                user, 
-                CompanySearch, 
-                request.StartIndex, 
+                user,
+                CompanySearch,
+                request.StartIndex,
                 request.Count ?? 10);
 
             return GridItemsProviderResult.From(paginationResult.Items.ToList(), paginationResult.TotalCount);
         }
 
-        public string GetRowCssClass(InterviewDTO interview)
+        public string? GetRowCssClass(InterviewDTO interview)
         {
-            if (!interview.Passed)
+            return selected != null && selected.Equals(interview) ? "table-primary fw-bold" : null;
+        }
+
+        public async Task SelectInterviewAsync(InterviewDTO args)
+        {
+            selected = args;
+            var historyKey = $"interview-messages-{args.Id}-{args.JobPostId}";
+            try
             {
-                return "declined-row";
+                History = await _interviewMessagesStore.LoadAsync(historyKey) ?? new List<ChatMessage>();
+                OnRequestUIUpdate?.Invoke();
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Failed to load interview messages for interview ID {InterviewId}", args.Id);
+                History = new List<ChatMessage>();
             }
 
-            return "applied-row";
+            Console.WriteLine($"Selected interview with ID: {args.Id}");
+        }
+
+        public async Task InitializeAsync()
+        {
+           OnRequestUIUpdate?.Invoke();            
         }
     }
 }

--- a/Components/Pages/JobPostPages/Index.razor
+++ b/Components/Pages/JobPostPages/Index.razor
@@ -1,6 +1,5 @@
 ﻿@page "/jobposts"
 
-@using Microsoft.AspNetCore.Components.QuickGrid
 @inject JobBank.Components.Pages.JobPostPages.ViewModels.IIndexViewModel IndexViewModel
 @rendermode InteractiveServer
 @attribute [Authorize]
@@ -61,7 +60,7 @@
 
     <div class="table-responsive rounded shadow-sm">
         <QuickGrid Class="table table-hover align-middle mb-0" 
-                   TGridItem="JobPostViewModel" 
+                   TGridItem="JobPostDataModel" 
                    ItemsProvider="IndexViewModel.GetJobPosts" 
                    Pagination="IndexViewModel.Pagination"
                    RowClass="@IndexViewModel.GetRowCssClass"
@@ -84,7 +83,7 @@
 
             <TemplateColumn Title="Outcome"
                             Sortable="true"
-                            SortBy="@(GridSort<JobPostViewModel>.ByAscending(x => x.InterviewOutcome))">
+                            SortBy="@(GridSort<JobPostDataModel>.ByAscending(x => x.InterviewOutcome))">
                 <span class="badge @(context.InterviewOutcome?.Contains("Reject") == true ? "bg-danger" : "bg-success")">
                     @context.InterviewOutcome
                 </span>

--- a/Components/Pages/JobPostPages/ViewModels/IIndexViewModel.cs
+++ b/Components/Pages/JobPostPages/ViewModels/IIndexViewModel.cs
@@ -1,14 +1,11 @@
-﻿using JobBank.Data;
-using JobBank.Models;
-using Microsoft.AspNetCore.Components;
+﻿using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.QuickGrid;
-using System.Linq.Expressions;
 
 namespace JobBank.Components.Pages.JobPostPages.ViewModels
 {
     public interface IIndexViewModel
     {
-        ValueTask<GridItemsProviderResult<JobPostViewModel>> GetJobPosts(GridItemsProviderRequest<JobPostViewModel> request);
+        ValueTask<GridItemsProviderResult<JobPostDataModel>> GetJobPosts(GridItemsProviderRequest<JobPostDataModel> request);
         PaginationState Pagination { get; }
 
         string JobTypeSearch { get; set; }
@@ -40,6 +37,6 @@ namespace JobBank.Components.Pages.JobPostPages.ViewModels
 
         void LoadPendingApplication(ChangeEventArgs ev);
 
-        string GetRowCssClass(JobPostViewModel jobPost);
+        string GetRowCssClass(JobPostDataModel jobPost);
     }
 }

--- a/Components/Pages/JobPostPages/ViewModels/IndexViewModel.cs
+++ b/Components/Pages/JobPostPages/ViewModels/IndexViewModel.cs
@@ -128,8 +128,8 @@ namespace JobBank.Components.Pages.JobPostPages.ViewModels
         /// </summary>
         /// <param name="request"></param>
         /// <returns></returns>
-        public async ValueTask<GridItemsProviderResult<JobPostViewModel>> GetJobPosts(
-        GridItemsProviderRequest<JobPostViewModel> request)
+        public async ValueTask<GridItemsProviderResult<JobPostDataModel>> GetJobPosts(
+        GridItemsProviderRequest<JobPostDataModel> request)
         {
             try
             {
@@ -147,7 +147,7 @@ namespace JobBank.Components.Pages.JobPostPages.ViewModels
                 var totalCount = await baseQuery.CountAsync(request.CancellationToken);
 
                 // Now project
-                var projectedQuery = baseQuery.Select(jp => new JobPostViewModel
+                var projectedQuery = baseQuery.Select(jp => new JobPostDataModel
                 {
                     Id = jp.Id,
                     Title = jp.Title,
@@ -214,7 +214,7 @@ namespace JobBank.Components.Pages.JobPostPages.ViewModels
         /// </summary>
         /// <param name="jobPost"></param>
         /// <returns></returns>
-        public string GetRowCssClass(JobPostViewModel jobPost)
+        public string GetRowCssClass(JobPostDataModel jobPost)
         {
             if (jobPost.ApplicationDeclined)
             {

--- a/Components/Pages/JobPostPages/ViewModels/JobPostDataModel.cs
+++ b/Components/Pages/JobPostPages/ViewModels/JobPostDataModel.cs
@@ -3,14 +3,14 @@ using System.ComponentModel.DataAnnotations;
 
 namespace JobBank.Components.Pages.JobPostPages.ViewModels
 {
-    public class JobPostViewModel
+    public class JobPostDataModel
     {
-        public JobPostViewModel()
+        public JobPostDataModel()
         {
                 
         }
 
-        public JobPostViewModel(JobPost post)
+        public JobPostDataModel(JobPost post)
         {
             Id = post.Id;
             Title = post.Title;
@@ -52,9 +52,9 @@ namespace JobBank.Components.Pages.JobPostPages.ViewModels
         /// 
         /// </summary>
         /// <param name="jobPost"></param>
-        public static implicit operator JobPostViewModel(JobPost jobPost)
+        public static implicit operator JobPostDataModel(JobPost jobPost)
         {
-            return new JobPostViewModel
+            return new JobPostDataModel
             {
                 Id = jobPost.Id,
                 Title = jobPost.Title,

--- a/Components/_Imports.razor
+++ b/Components/_Imports.razor
@@ -25,7 +25,11 @@
 @using JobBank.Components.Pages.JobPostPages.ViewModels
 @using JobBank.Components.Pages.Init
 @using JobBank.Components.Pages.SkillPages.ViewModels
+@using JobBank.Components.Pages.InterviewLibrary.ViewModels
+@using JobBank.ModelsDTO
 @using System.Threading.Channels
 @using Microsoft.AspNetCore.Routing;
 @using Microsoft.AspNetCore.Authorization
 @using Microsoft.AspNetCore.Components.Authorization
+@using Microsoft.AspNetCore.Components.QuickGrid
+@using JobBank.Management.Abstraction

--- a/JobBank.csproj
+++ b/JobBank.csproj
@@ -4,6 +4,7 @@
     <TargetFramework>net10.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
+	  <StaticWebAssetBasePath>/</StaticWebAssetBasePath>
   </PropertyGroup>
 
 	<PropertyGroup>

--- a/Management/Abstraction/IInterviewLLMService.cs
+++ b/Management/Abstraction/IInterviewLLMService.cs
@@ -2,14 +2,8 @@
 
 namespace JobBank.Management.Abstraction
 {
-    public interface IInterviewLLMService
+    public partial interface IInterviewLLMService
     {
-        public enum InterviewRole
-        {
-            Interviewer,
-            User
-        }
-
         Task<InterviewerLLMDTO> GetInterviewerAnalysisAsync(UserJobApplicantDTO userDTO, string prompt);
     }
 }

--- a/Management/Abstraction/InterviewRole.cs
+++ b/Management/Abstraction/InterviewRole.cs
@@ -1,0 +1,8 @@
+﻿namespace JobBank.Management.Abstraction
+{
+    public enum InterviewRole
+    {
+        Interviewer,
+        User
+    }
+}

--- a/Migrations/20260509002429_TrainerInterviewSoftDelMigration.Designer.cs
+++ b/Migrations/20260509002429_TrainerInterviewSoftDelMigration.Designer.cs
@@ -4,6 +4,7 @@ using JobBank.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace JobBank.Migrations
 {
     [DbContext(typeof(EmploymentBankContext))]
-    partial class JobBankContextModelSnapshot : ModelSnapshot
+    [Migration("20260509002429_TrainerInterviewSoftDelMigration")]
+    partial class TrainerInterviewSoftDelMigration
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Migrations/20260509002429_TrainerInterviewSoftDelMigration.cs
+++ b/Migrations/20260509002429_TrainerInterviewSoftDelMigration.cs
@@ -1,0 +1,40 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace JobBank.Migrations
+{
+    /// <inheritdoc />
+    public partial class TrainerInterviewSoftDelMigration : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<bool>(
+                name: "IsDeleted",
+                table: "Trainings",
+                type: "bit",
+                nullable: false,
+                defaultValue: false);
+
+            migrationBuilder.AddColumn<bool>(
+                name: "IsDeleted",
+                table: "Interviews",
+                type: "bit",
+                nullable: false,
+                defaultValue: false);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "IsDeleted",
+                table: "Trainings");
+
+            migrationBuilder.DropColumn(
+                name: "IsDeleted",
+                table: "Interviews");
+        }
+    }
+}

--- a/ModelConfiguration/InterviewConfiguration.cs
+++ b/ModelConfiguration/InterviewConfiguration.cs
@@ -20,6 +20,9 @@ namespace JobBank.ModelConfiguration
             builder.Property(b => b.Prompt)
                 .IsRequired();
 
+            builder.Property(b => b.IsDeleted)
+                .HasDefaultValue(false);
+
             builder
                 .Property(b => b.CreatedDateUtc)
                 .HasDefaultValueSql("GETUTCDATE()")

--- a/ModelConfiguration/TrainingConfiguration.cs
+++ b/ModelConfiguration/TrainingConfiguration.cs
@@ -27,6 +27,9 @@ namespace JobBank.ModelConfiguration
             builder.Property(b => b.Prompt)
                 .IsRequired();
 
+            builder.Property(b => b.IsDeleted)
+                .HasDefaultValue(false);
+
             builder.HasOne(b => b.Interview)
                 .WithOne(i => i.Training)
                 .HasForeignKey<Training>(b => b.InterviewId)

--- a/ModelMapping/InterviewMappingProfile.cs
+++ b/ModelMapping/InterviewMappingProfile.cs
@@ -1,12 +1,20 @@
 ﻿using AutoMapper;
 
+using JobBank.Models;
+using JobBank.ModelsDTO;
+
 namespace JobBank.ModelMapping
 {
     public class InterviewMappingProfile : Profile
     {
         public InterviewMappingProfile() 
         {
-            CreateMap<Models.Interview, ModelsDTO.InterviewDTO>().ReverseMap();
+            CreateMap<Interview, InterviewDTO>()
+                .ForMember(dest => dest.JobTitle, opt => opt.MapFrom(src => src.JobPost != null ? src.JobPost.Title : string.Empty))
+                .ForMember(dest => dest.Company, opt => opt.MapFrom(src => src.JobPost != null ? src.JobPost.Company : string.Empty))
+                .ForMember(dest => dest.TrainingId, opt => opt.MapFrom(src => src.Training != null ? src.Training.Id : 0));
+
+            CreateMap<InterviewDTO, Interview>();
         }
     }
 }

--- a/Models/Interview.cs
+++ b/Models/Interview.cs
@@ -33,6 +33,8 @@ namespace JobBank.Models
         public int NumberOfQuestions { get; set; }
         public bool IsCompleted { get; set; }
 
+        public bool IsDeleted { get; set; }
+
         public virtual Training? Training { get; set; }
     }
 }

--- a/Models/Training.cs
+++ b/Models/Training.cs
@@ -19,5 +19,7 @@ namespace JobBank.Models
 
         public int InterviewId { get; set; }
         public virtual Interview Interview { get; set; }
+
+        public bool IsDeleted { get; set; }
     }
 }

--- a/ModelsDTO/InterviewDTO.cs
+++ b/ModelsDTO/InterviewDTO.cs
@@ -1,6 +1,6 @@
 ﻿namespace JobBank.ModelsDTO
 {
-    public class InterviewDTO
+    public class InterviewDTO : IEquatable<InterviewDTO>
     {
         public int Id { get; set; }
 
@@ -35,5 +35,51 @@
         public string Company { get; set; } = string.Empty;
 
         public int TrainingId { get; set; }
+
+        public override bool Equals(object? obj)
+        {
+            return Equals(obj as InterviewDTO);
+        }
+
+        public bool Equals(InterviewDTO? other)
+            => other is not null &&
+               Id == other.Id &&
+               JobPostId == other.JobPostId &&
+               UserId == other.UserId &&
+               Result == other.Result &&
+               CreatedDateUtc == other.CreatedDateUtc &&
+               StartedAtUtc == other.StartedAtUtc &&
+               CompletedAtUtc == other.CompletedAtUtc &&
+               Model == other.Model &&
+               Prompt == other.Prompt &&
+               ScoreTotal == other.ScoreTotal &&
+               ScoreMax == other.ScoreMax &&
+               Passed == other.Passed &&
+               NumberOfQuestions == other.NumberOfQuestions &&
+               IsCompleted == other.IsCompleted &&
+               IsDeleted == other.IsDeleted &&
+               JobTitle == other.JobTitle &&
+               Company == other.Company &&
+               TrainingId == other.TrainingId;
+
+        public override int GetHashCode() => (
+            Id,
+            JobPostId,
+            UserId,
+            Result,
+            CreatedDateUtc,
+            StartedAtUtc,
+            CompletedAtUtc,
+            Model,
+            Prompt,
+            ScoreTotal,
+            ScoreMax,
+            Passed,
+            NumberOfQuestions,
+            IsCompleted,
+            IsDeleted,
+            JobTitle,
+            Company,
+            TrainingId).GetHashCode();
     }
 }

--- a/ModelsDTO/InterviewDTO.cs
+++ b/ModelsDTO/InterviewDTO.cs
@@ -29,5 +29,11 @@
         public bool IsCompleted { get; set; }
 
         public bool IsDeleted { get; set; }
+
+        public string JobTitle { get; set; } = string.Empty;
+
+        public string Company { get; set; } = string.Empty;
+
+        public int TrainingId { get; set; }
     }
 }

--- a/ModelsDTO/InterviewDTO.cs
+++ b/ModelsDTO/InterviewDTO.cs
@@ -27,5 +27,7 @@
 
         public int NumberOfQuestions { get; set; }
         public bool IsCompleted { get; set; }
+
+        public bool IsDeleted { get; set; }
     }
 }

--- a/ModelsDTO/TrainingDTO.cs
+++ b/ModelsDTO/TrainingDTO.cs
@@ -9,5 +9,7 @@
         public string Model { get; set; } = string.Empty;
         public string Prompt { get; set; } = string.Empty;
         public int InterviewId { get; set; }
+
+        public bool IsDeleted { get; set; }
     }
 }

--- a/Program.cs
+++ b/Program.cs
@@ -3,6 +3,7 @@ using JobBank.Components;
 using JobBank.Components.Account;
 using JobBank.Components.Pages.Home.ViewModels;
 using JobBank.Components.Pages.Interviewer.ViewModels;
+using JobBank.Components.Pages.InterviewLibrary.ViewModels;
 using JobBank.Components.Pages.JobPostPages.ViewModels;
 using JobBank.Components.Pages.SkillPages.ViewModels;
 using JobBank.Data;
@@ -114,6 +115,7 @@ builder.Services.AddScoped<IIndexViewModel, IndexViewModel>()
     .AddScoped<ISkillMacthAnalysisViewModel, SkillMacthAnalysisViewModel>()
     .AddScoped<FilteredStateService>()
     .AddScoped<IJobPostService, JobPostService>()
+    .AddScoped<IInterviewLibraryViewModel, InterviewLibraryViewModel>()
     .AddScoped<ISkillsService, SkillsService>()
     .AddScoped<ITrainingService, TrainingServcie>()
     .AddScoped<IAnalysisCacheService, AnalysisCacheService>()

--- a/Services/Abstraction/IInterviewService.cs
+++ b/Services/Abstraction/IInterviewService.cs
@@ -1,12 +1,22 @@
-﻿using JobBank.ModelsDTO;
+﻿using Azure.Core;
+using JobBank.ModelsDTO;
 
 namespace JobBank.Services.Abstraction
 {
     public interface IInterviewService : IAsyncDisposable
     {
         Task<InterviewDTO> GetInterviewByIdAsync(int id);
-        Task<IEnumerable<InterviewDTO>> GetInterviewsByUserIdAsync(string userId);
+        Task<IEnumerable<InterviewDTO>> GetInterviewsByUserIdAsync(string userId, bool isDeleted = false);            
+
+        Task<PaginationResult<InterviewDTO>> GetInterviewsByUserIdWithPaginationAsync(string userId, string companyName, int startIndex, int take, bool isDeleted = false);
+
         Task<IEnumerable<InterviewDTO>> GetInterviewsByJobPostIdAsync(int id);
         Task AddInterviewAsync(InterviewDTO emp);
+    }
+
+    public class PaginationResult<T> where T : class
+    {
+        public IEnumerable<T> Items { get; set; } = Enumerable.Empty<T>();
+        public int TotalCount { get; set; }
     }
 }

--- a/Services/InterviewService.cs
+++ b/Services/InterviewService.cs
@@ -11,23 +11,28 @@ namespace JobBank.Services
 {
     public class InterviewService : IInterviewService
     {
-        private readonly EmploymentBankContext _context;
+        private readonly IDbContextFactory<EmploymentBankContext> _dbFactory;
         private readonly IMapper _mapper;
 
         public InterviewService(IDbContextFactory<EmploymentBankContext> dbFactory, IMapper mapper)
         {
             _mapper = mapper;
-            _context = dbFactory.CreateDbContext();
+            _dbFactory = dbFactory;
         }
 
-        public async ValueTask DisposeAsync() => await _context.DisposeAsync();
+        public async ValueTask DisposeAsync()
+        {
+            await ValueTask.CompletedTask;
+        }
 
         public async Task<InterviewDTO> GetInterviewByIdAsync(int interviewId)
         {
             try
             {
-                return await _context.Interviews
+                await using var context = _dbFactory.CreateDbContext();
+                return await context.Interviews
                     .Where(i => i.Id == interviewId)
+                    .Include(i => i.JobPost)
                     .ProjectTo<InterviewDTO>(_mapper.ConfigurationProvider)
                     .FirstOrDefaultAsync();
             }
@@ -41,8 +46,10 @@ namespace JobBank.Services
         {
             try
             {
-                return await _context.Interviews
+                await using var context = _dbFactory.CreateDbContext();
+                return await context.Interviews
                     .Where(i => i.JobPostId == jobPostId)
+                    .Include(i => i.JobPost)
                     .ProjectTo<InterviewDTO>(_mapper.ConfigurationProvider)
                     .ToListAsync();
             }
@@ -52,12 +59,14 @@ namespace JobBank.Services
             }
         }
 
-        public async Task<IEnumerable<InterviewDTO>> GetInterviewsByUserIdAsync(string userId)
+        public async Task<IEnumerable<InterviewDTO>> GetInterviewsByUserIdAsync(string userId, bool isDeleted = false)
         {
             try
             {
-                return await _context.Interviews
-                    .Where(i => i.UserId == userId)
+                await using var context = _dbFactory.CreateDbContext();
+                return await context.Interviews
+                    .Where(i => i.UserId == userId && i.IsDeleted == isDeleted)
+                    .Include(i => i.JobPost)
                     .ProjectTo<InterviewDTO>(_mapper.ConfigurationProvider)
                     .ToListAsync();
             }
@@ -67,22 +76,66 @@ namespace JobBank.Services
             }
         }
 
+        public async Task<PaginationResult<InterviewDTO>> GetInterviewsByUserIdWithPaginationAsync(
+            string userId,
+            string companyName,
+            int startIndex,
+            int take,
+            bool isDeleted = false)
+        {
+            try
+            {
+                await using var context = _dbFactory.CreateDbContext();
+                IQueryable<Interview> query = context.Interviews
+                    .Where(i => i.UserId == userId && i.IsDeleted == isDeleted)
+                    .Include(i => i.JobPost);
+
+                if (!string.IsNullOrWhiteSpace(companyName))
+                {
+                    query = query.Where(i => EF.Functions.Like(i.JobPost.Company, $"%{companyName}%"));
+                }
+
+                var orderedQuery = query.OrderByDescending(i => i.CompletedAtUtc);
+                
+                var totalCount = await orderedQuery.CountAsync();
+                var interviews = await orderedQuery
+                    .Skip(startIndex)
+                    .Take(take)
+                    .ProjectTo<InterviewDTO>(_mapper.ConfigurationProvider)
+                    .ToListAsync();
+
+                return new PaginationResult<InterviewDTO>
+                {
+                    Items = interviews,
+                    TotalCount = totalCount
+                };
+            }
+            catch (InvalidOperationException ex)
+            {
+                throw new DataIntegrityException("GetInterviewsByUserIdWithPaginationAsync: A system error occurred. Please contact support.", ex);
+            }
+        }
+
         public async Task AddInterviewAsync(InterviewDTO interviewDto)
         {
-            if (interviewDto.Id != 0) // there will never be the case of an update
+            if (interviewDto == null)
+                throw new ArgumentNullException(nameof(interviewDto), "Interview DTO cannot be null.");
+
+            if (interviewDto.Id != 0)
                 throw new ArgumentException("Interview ID must be zero when adding a new interview.");
 
             try
             {
+                await using var context = _dbFactory.CreateDbContext();
                 var interview = _mapper.Map<Interview>(interviewDto);
-                _context.Interviews.Add(interview);                
-                await _context.SaveChangesAsync();
-                interviewDto.Id = interview.Id; // update the DTO with the generated ID
+                context.Interviews.Add(interview);
+                await context.SaveChangesAsync();
+                interviewDto.Id = interview.Id;
             }
             catch (InvalidOperationException ex)
             {
                 throw new DataIntegrityException("AddInterviewAsync: A system error occurred. Please contact support.", ex);
-            }            
+            }
         }
     }
 }

--- a/wwwroot/app.css
+++ b/wwwroot/app.css
@@ -68,6 +68,11 @@ h1:focus {
     color: #842029;
 }
 
+.selected-row {
+    background-color: #b5e2eb !important;
+    font-weight: bold !important;
+}
+
 .modal-backdrop {
    background-color: rgba(0, 0, 0, 0.5) !important;
 }


### PR DESCRIPTION
- WC loads Interviews into the Interview Library
- The Interview grid offers two actions: "Transcript", "Training"
- Training action is disabled if the interview has no training. This should not happen, these are early interviews. The interview has the analysis metadata it it the training could be generated by the model. However, the current workflow does not include this change.
- Transcript loads the interview conversation into the conversation card.